### PR TITLE
Version 1.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+## VSCODE
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ To install stig-parser, simple run the following command:
 
 `pip install stig-parser`
 
+## Version Updates
+
+| Version | Description |
+| :---: | --- | 
+| 1.0.0 | Initial Creation of `stig-parser` |
+| 1.0.1 | Updated to handle change to STIG schema ([Issue #3](/../../issues/3)) |
+
 ## Documentation
 
 Documentation hasn't been created at this time. For the current development documentation, please visit the [repository](https://github.com/pkeech/stig_parser).

--- a/README.md
+++ b/README.md
@@ -31,6 +31,43 @@ json_results = convert_xccdf(raw_file)
 
 ```
 
+## Output
+
+Outlined below is the expected JSON output:
+
+``` json
+{
+    benchmark_date: "xxxxxxx",
+    description: "xxxxxxxx",
+    release: "xx",
+    rules: [
+        {
+            "check": "xxxxxxxx", 
+            "description": "xxxxxxxxxx", 
+            "fixtext": "xxxxxxxxxx", 
+            "id": "xxxxxxx", 
+            "severity": "xxxxxxxx", 
+            "stig_id": "xx-xx-xxxxxx", 
+            "title": "xxxxxxxxxxx"
+        },
+        {
+            "check": "xxxxxxxx", 
+            "description": "xxxxxxxxxx", 
+            "fixtext": "xxxxxxxxxx", 
+            "id": "xxxxxxx", 
+            "severity": "xxxxxxxx", 
+            "stig_id": "xx-xx-xxxxxx", 
+            "title": "xxxxxxxxxxx"
+        }
+    ],
+    title: "xxxxxxxxxx",
+    version: "xxxxxxxxx"
+}
+
+
+```
+
+
 ## Dependencies
 
 The following packages are required for this package:

--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ Outlined below is the expected JSON output:
     title: "xxxxxxxxxx",
     version: "xxxxxxxxx"
 }
-
-
 ```
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='stig_parser',  
-    version='1.0.0',
+    version='1.0.1',
     author="Peter Keech",
     author_email="peter.a.keech@gmail.com",
     description="A Python module to parse DISA STIG (XCCDF) Files",

--- a/stig_parser/__init__.py
+++ b/stig_parser/__init__.py
@@ -11,12 +11,19 @@ import os, xmltodict, json
 def convert_xccdf(raw):
     ## CREATE XSD PATH
     #filepath = resource_filename(__name__, 'xccdf-1.1.4.xsd')
-    
+        
     ## CONVERT XML TO PYTHON DICTIONARY
     content_dict = xmltodict.parse(raw)
 
+    ## HANDLE NEW VS. OLD VERSION OF STIG SCHEMA (ISSUE #3)
+    if isinstance(content_dict['Benchmark']['plain-text'], list):
+        ## NEW VERSION
+        raw_version = content_dict['Benchmark']['plain-text'][0]['#text']
+    else:
+        ## OLD VERSION
+        raw_version = content_dict['Benchmark']['plain-text']['#text']        
+
     ## PARSE DATE AND RELEASE DATA
-    raw_version = content_dict['Benchmark']['plain-text']['#text']
     raw_version = raw_version.split('Benchmark Date: ')
     BENCH_DATE = raw_version[1]
     REL = raw_version[0].replace('Release: ','')


### PR DESCRIPTION
Updated module to handle changes to STIG schema. 

This update is backwards compatible, allowing STIGs released pre OCT 2020 to still function as normal. 