### PR TITLE
Gracefully handle Rules containing array of ident values

### DIFF
--- a/src/stig_parser/stig_parser.py
+++ b/src/stig_parser/stig_parser.py
@@ -104,25 +104,37 @@ def convert_xccdf(RAW):
     ## GENERATE EMPTY ARRAY
     STIGS = []
 
-    ## LOOP THROUGH STIGS
-    for STIG in CONTENT_DICT['Benchmark']['Group']:
-
-        ## PARSE IDENT 
-        IDENT = STIG['Rule']['ident']
-
+    def get_cci_list(IDENT):
         ## HANDLE MULTIPLE IDENT ENTRIES (CCI)
         if len(IDENT) == 2:
             IDENT = IDENT['#text']
         else:
             ## DEFINE EMPTY RESULTS
             RESULTS = ""
-        
+
             ## LOOP THROUGH ALL CCI NUMBERS
             for RESULT in IDENT:
                 RESULTS += RESULT['#text'] + ","
 
             ## REMOVE LAST ','
             IDENT = RESULTS.rstrip(RESULTS[-1])
+        return IDENT
+
+    ## LOOP THROUGH STIGS
+    for STIG in CONTENT_DICT['Benchmark']['Group']:
+
+        ## PARSE IDENT
+        IDENT = STIG['Rule']['ident']
+
+        ## HANDLE ARRAY CASE
+        IDENT_LIST = ""
+        if type(IDENT) == list:
+            for IDENT_ITEM in IDENT:
+                IDENT_LIST += get_cci_list(IDENT_ITEM) + ","
+        else:
+            IDENT_LIST += get_cci_list(IDENT) + ","
+        ## REMOVE LAST ','
+        IDENT = IDENT_LIST.rstrip(IDENT_LIST[-1])
         
         ## FORMAT SEVERITY
         ## TODO: DOCUMENT WHY THIS IS HAPPENING. STIGVIEWER CONVERTS LOW/MED/HIGH TO CAT III/CAT II/CAT I


### PR DESCRIPTION
Fixes issue #37 https://github.com/pkeech/stig_parser/issues/37

Some STIGS actually had a array of ident enties and not just a list of values within an ident entry.